### PR TITLE
Fixing double slash in the loader image output

### DIFF
--- a/popular-posts-tab-widget-for-jetpack.php
+++ b/popular-posts-tab-widget-for-jetpack.php
@@ -378,7 +378,7 @@ requires the Jetpack Stats module to be enabled.', 'pptwj' ), 'http://wordpress.
 						</ul>
 					</div><!-- #tab-comm -->
 					<?php } ?>
-					<div class="pptwj-loader"><img src="<?php echo includes_url(); ?>/images/wpspin-2x.gif" alt="Ajax spinner"></div>
+					<div class="pptwj-loader"><img src="<?php echo includes_url( '/images/wpspin-2x.gif' ); ?>" alt="Ajax spinner"></div>
 				</div><!-- /.boxes -->
 			</div><!-- /pptwj-tabs-wrap -->
 


### PR DESCRIPTION
The url shows up as /wp-includes//images/wpspin-2x.gif, this fixes that double slash (which seems to cause an error when SSL is enabled)
